### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
See the individual commits for the 3 separate suggested github actions fixes.

In short, all 3 actions had wide open token permissions; the suggestion was to limit the tokens to exactly what the actions needed.
